### PR TITLE
chore: update tag workflow #patch

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -20,3 +20,4 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.TAG_GITHUB_TOKEN }}
         WITH_V: false
+        DEFAULT_BUMP: patch


### PR DESCRIPTION
It replaces `minor` with `patch` as the default.